### PR TITLE
Fix error caused invalid null-safety usage

### DIFF
--- a/lib/nowplaying.dart
+++ b/lib/nowplaying.dart
@@ -90,8 +90,9 @@ class NowPlaying with WidgetsBindingObserver {
   }
 
   /// Returns true is the service has permission granted by the systme and user
-  Future<bool> isEnabled() async =>
-      isIOS || await (_channel.invokeMethod<bool>('isEnabled') as FutureOr<bool>);
+  Future<bool> isEnabled() async {
+    return isIOS || (await _channel.invokeMethod<bool>('isEnabled') ?? false);
+  }
 
   /// Opens an OS settings page
   ///

--- a/lib/nowplaying.dart
+++ b/lib/nowplaying.dart
@@ -121,7 +121,7 @@ class NowPlaying with WidgetsBindingObserver {
   // Android
   Future<dynamic> _handler(MethodCall call) async {
     if (call.method == 'track') {
-      final data = Map<String, Object>.from(call.arguments[0] ?? {});
+      final data = Map<String, Object?>.from(call.arguments[0] ?? {});
       _updateAndNotifyFor(NowPlayingTrack.fromJson(data));
     }
     return true;
@@ -131,7 +131,7 @@ class NowPlaying with WidgetsBindingObserver {
   // iOS
   Future<void> _refresh([_]) async {
     final data = await _channel.invokeMethod('track');
-    final json = Map<String, Object>.from(data);
+    final json = Map<String, Object?>.from(data);
     final track = NowPlayingTrack.fromJson(json);
     if (_shouldNotifyFor(track)) _updateAndNotifyFor(track);
   }


### PR DESCRIPTION
This PR fixes the type case error that causes when using the `isEnabled()` function like below. And also fixes the null exception caused by a convert to an Object that can be null.
```console
E/flutter (29179): [ERROR:flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: type 'Future<bool?>' is not a subtype of type 'FutureOr<bool>' in type cast
E/flutter (29179): #0      NowPlaying.isEnabled (package:nowplaying/nowplaying.dart:94:64)
E/flutter (29179): #1      _MyAppState.initState (package:nowplaying_example/main.dart:21:25)
E/flutter (29179): #2      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4711:57)
E/flutter (29179): #3      ComponentElement.mount (package:flutter/src/widgets/framework.dart:4548:5)
E/flutter (29179): #4      Element.inflateWidget (package:flutter/src/widgets/framework.dart:3611:14)
E/flutter (29179): #5      Element.updateChild (package:flutter/src/widgets/framework.dart:3363:18)
```

