### PR TITLE
Example migrated to provider 6.0.0

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,41 +37,45 @@ class _MyAppState extends State<MyApp> {
             title: const Text('NowPlaying example app'),
           ),
           body: Center(
-              child: Consumer<NowPlayingTrack>(builder: (context, track, _) {
-            if (track == null) return Container();
-            return Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                if (track.isStopped) Text('nothing playing'),
-                if (!track.isStopped) ...[
-                  if (track.title != null) Text(track.title),
-                  if (track.artist != null) Text(track.artist),
-                  if (track.album != null) Text(track.album),
-                  if (track.duration != null)
-                    Text(track.duration
-                        .toString()
-                        .split('.')
-                        .first
-                        .padLeft(8, '0')),
-                  TrackProgressIndicator(track),
-                  Text(track.state.toString()),
-                  Stack(
-                    alignment: Alignment.center,
-                    children: [
-                      Container(
-                          margin: const EdgeInsets.all(8.0),
-                          width: 200,
-                          height: 200,
-                          alignment: Alignment.center,
-                          color: Colors.grey,
-                          child: _imageFrom(track)),
-                      Positioned(bottom: 0, right: 0, child: _iconFrom(track))
-                    ],
-                  ),
-                ]
-              ],
-            );
-          })),
+            child: Consumer<NowPlayingTrack>(
+              builder: (context, track, _) {
+                if (track == null) return Container();
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (track.isStopped) Text('nothing playing'),
+                    if (!track.isStopped) ...[
+                      if (track.title != null) Text(track.title),
+                      if (track.artist != null) Text(track.artist),
+                      if (track.album != null) Text(track.album),
+                      if (track.duration != null)
+                        Text(track.duration
+                            .toString()
+                            .split('.')
+                            .first
+                            .padLeft(8, '0')),
+                      TrackProgressIndicator(track),
+                      Text(track.state.toString()),
+                      Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          Container(
+                              margin: const EdgeInsets.all(8.0),
+                              width: 200,
+                              height: 200,
+                              alignment: Alignment.center,
+                              color: Colors.grey,
+                              child: _imageFrom(track)),
+                          Positioned(
+                              bottom: 0, right: 0, child: _iconFrom(track))
+                        ],
+                      ),
+                    ]
+                  ],
+                );
+              },
+            ),
+          ),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,7 +28,8 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamProvider.value(
+    return StreamProvider<NowPlayingTrack>.value(
+      initialData: null,
       value: NowPlaying.instance.stream,
       child: MaterialApp(
         home: Scaffold(
@@ -36,83 +37,97 @@ class _MyAppState extends State<MyApp> {
             title: const Text('NowPlaying example app'),
           ),
           body: Center(
-            child: Consumer<NowPlayingTrack>(
-              builder: (context, track, _) {
-                if (track == null) return Container();
-                return Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    if (track.isStopped) Text('nothing playing'),
-                    if (!track.isStopped) ...[
-                      if (track.title != null) Text(track.title),
-                      if (track.artist != null) Text(track.artist),
-                      if (track.album != null) Text(track.album),
-                      if (track.duration != null) Text(track.duration.toString().split('.').first.padLeft(8, '0')),
-                      TrackProgressIndicator(track),
-                      Text(track.state.toString()),
-                      Stack(
-                        alignment: Alignment.center,
-                        children: [
-                          Container(
-                            margin: const EdgeInsets.all(8.0),
-                            width: 200,
-                            height: 200,
-                            alignment: Alignment.center,
-                            color: Colors.grey,
-                            child: _imageFrom(track)
-                          ),
-                          Positioned(bottom: 0, right: 0, child: _iconFrom(track))
-                        ],
-                      ),
-                    ]
-                  ],
-                );
-              }
-            )
-          ),
+              child: Consumer<NowPlayingTrack>(builder: (context, track, _) {
+            if (track == null) return Container();
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (track.isStopped) Text('nothing playing'),
+                if (!track.isStopped) ...[
+                  if (track.title != null) Text(track.title),
+                  if (track.artist != null) Text(track.artist),
+                  if (track.album != null) Text(track.album),
+                  if (track.duration != null)
+                    Text(track.duration
+                        .toString()
+                        .split('.')
+                        .first
+                        .padLeft(8, '0')),
+                  TrackProgressIndicator(track),
+                  Text(track.state.toString()),
+                  Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Container(
+                          margin: const EdgeInsets.all(8.0),
+                          width: 200,
+                          height: 200,
+                          alignment: Alignment.center,
+                          color: Colors.grey,
+                          child: _imageFrom(track)),
+                      Positioned(bottom: 0, right: 0, child: _iconFrom(track))
+                    ],
+                  ),
+                ]
+              ],
+            );
+          })),
         ),
       ),
     );
   }
 
   Widget _imageFrom(NowPlayingTrack track) {
-    if (track.hasImage) return Image(key: Key(track.id), image: track.image, width: 200, height: 200, fit: BoxFit.contain);
+    if (track.hasImage)
+      return Image(
+          key: Key(track.id),
+          image: track.image,
+          width: 200,
+          height: 200,
+          fit: BoxFit.contain);
 
-    if (track.isResolvingImage) return Container(
-      width: 50.0,
-      height: 50.0,
-      child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
-    );
+    if (track.isResolvingImage)
+      return Container(
+          width: 50.0,
+          height: 50.0,
+          child: CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.white)));
 
-    return Text('NO\nARTWORK\nFOUND', textAlign: TextAlign.center, style: const TextStyle(fontSize: 24, color: Colors.white));
+    return Text('NO\nARTWORK\nFOUND',
+        textAlign: TextAlign.center,
+        style: const TextStyle(fontSize: 24, color: Colors.white));
   }
 
   Widget _iconFrom(NowPlayingTrack track) {
-    if (track.hasIcon) return Container(
-      padding: const EdgeInsets.all(6),
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        boxShadow: [const BoxShadow(blurRadius: 5, color: Colors.black)],
-        shape: BoxShape.circle
-      ),
-      child: Image(
-        image: track.icon,
-        width: 25,
-        height: 25,
-        fit: BoxFit.contain,
-        color: _fgColorFor(track),
-        colorBlendMode: BlendMode.srcIn,
-      ),
-    );
+    if (track.hasIcon)
+      return Container(
+        padding: const EdgeInsets.all(6),
+        decoration: const BoxDecoration(
+            color: Colors.white,
+            boxShadow: [const BoxShadow(blurRadius: 5, color: Colors.black)],
+            shape: BoxShape.circle),
+        child: Image(
+          image: track.icon,
+          width: 25,
+          height: 25,
+          fit: BoxFit.contain,
+          color: _fgColorFor(track),
+          colorBlendMode: BlendMode.srcIn,
+        ),
+      );
     return Container();
   }
 
   Color _fgColorFor(NowPlayingTrack track) {
     switch (track.source) {
-      case "com.apple.music": return Colors.blue;
-      case "com.hughesmedia.big_finish": return Colors.red;
-      case "com.spotify.music": return Colors.green;
-      default: return Colors.purpleAccent;
+      case "com.apple.music":
+        return Colors.blue;
+      case "com.hughesmedia.big_finish":
+        return Colors.red;
+      case "com.spotify.music":
+        return Colors.green;
+      default:
+        return Colors.purpleAccent;
     }
   }
 }
@@ -144,7 +159,8 @@ class _TrackProgressIndicatorState extends State<TrackProgressIndicator> {
   @override
   Widget build(BuildContext context) {
     final progress = widget.track.progress;
-    final countdown = widget.track.duration - progress + const Duration(seconds: 1);
+    final countdown =
+        widget.track.duration - progress + const Duration(seconds: 1);
     return Column(
       children: [
         Text(progress.toString().split('.').first.padLeft(8, '0')),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -101,7 +101,7 @@ packages:
       name: nested
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4"
+    version: "1.0.0"
   nowplaying:
     dependency: "direct main"
     description:
@@ -185,7 +185,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2+2"
+    version: "6.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
-  provider: ^4.3.2+2
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi there,
I recently helped somebody on stackoverflow, who tried implementing your example app from pub.dev.

As the provider package since version 5.0.0-nullsafety requires initialData for both FutureProvider and StreamProvider, I migrated it in adherence to the provider documentation.
Moreover, your example does not specify the concrete provider type for the StreamProvider, which caused the problem posted on SO. 

All changes besides line 31 & 32 are whitespacing changes to make the code more readable in an IDE.


Best regards,
Jahn


PS: SO link: https://stackoverflow.com/q/69140257/15117201 - by the way, my third tip in my answer was wrong, because I overlooked your initState().